### PR TITLE
Fix searching for groups by name.

### DIFF
--- a/app/model/repository/Groups.php
+++ b/app/model/repository/Groups.php
@@ -82,6 +82,7 @@ class Groups extends BaseSoftDeleteRepository  {
     }
 
     $groupsQb->andWhere($groupsQb->expr()->eq("i.id", ":instanceId"));
+    $groupsQb->andWhere($groupsQb->expr()->isNull("g.deletedAt"));
     $groupsQb->andWhere($groupsQb->expr()->orX(...$criteria));
 
     if ($parentGroup) {


### PR DESCRIPTION
The previous implementation included soft-deleted entities in the
results, which resulted in failed group name validations.