### PR TITLE
Only create new entities for exercise configuration when needed.

### DIFF
--- a/app/V1Module/presenters/ExercisesConfigPresenter.php
+++ b/app/V1Module/presenters/ExercisesConfigPresenter.php
@@ -195,17 +195,18 @@ class ExercisesConfigPresenter extends BasePresenter {
       $variablesTable = $this->exerciseConfigLoader->loadVariablesTable($varTableArray);
 
       // create all new runtime configuration
+      $oldConfig = $exercise->getExerciseEnvironmentConfigByEnvironment($environment);
       $config = new ExerciseEnvironmentConfig(
         $environment,
         (string) $variablesTable,
         $this->getCurrentUser(),
-        $exercise->getExerciseEnvironmentConfigByEnvironment($environment)
+        $oldConfig
       );
 
       // validation of newly create environment config
       $this->configValidator->validateEnvironmentConfig($exercise, $variablesTable);
 
-      $configs[$environmentId] = $config;
+      $configs[$environmentId] = !$config->equals($oldConfig) ? $config: $oldConfig;
     }
 
     // make changes and updates to database entity

--- a/app/V1Module/presenters/ExercisesConfigPresenter.php
+++ b/app/V1Module/presenters/ExercisesConfigPresenter.php
@@ -411,10 +411,12 @@ class ExercisesConfigPresenter extends BasePresenter {
 
       // remove old limits for corresponding environment and hwgroup and add new
       // ones, also do not forget to set hwgroup to exercise
-      $exercise->removeExerciseLimits($oldLimits); // if there were ones before
-      $exercise->addExerciseLimits($newLimits);
-      $exercise->removeHardwareGroup($hwGroup); // if there was one before
-      $exercise->addHardwareGroup($hwGroup);
+      if (!$newLimits->equals($oldLimits)) {
+        $exercise->removeExerciseLimits($oldLimits); // if there were ones before
+        $exercise->addExerciseLimits($newLimits);
+        $exercise->removeHardwareGroup($hwGroup); // if there was one before
+        $exercise->addHardwareGroup($hwGroup);
+      }
     }
 
     // update and return

--- a/app/V1Module/presenters/ExercisesConfigPresenter.php
+++ b/app/V1Module/presenters/ExercisesConfigPresenter.php
@@ -281,14 +281,16 @@ class ExercisesConfigPresenter extends BasePresenter {
 
     // new config was provided, so construct new database entity
     $newConfig = new ExerciseConfig((string) $exerciseConfig, $this->getCurrentUser(), $oldConfig);
+    
+    if (!$newConfig->equals($oldConfig)) {
+      // set new exercise configuration into exercise and flush changes
+      $exercise->updatedNow();
+      $exercise->setExerciseConfig($newConfig);
+      $this->exercises->flush();
 
-    // set new exercise configuration into exercise and flush changes
-    $exercise->updatedNow();
-    $exercise->setExerciseConfig($newConfig);
-    $this->exercises->flush();
-
-    $this->configChecker->check($exercise);
-    $this->exercises->flush();
+      $this->configChecker->check($exercise);
+      $this->exercises->flush();
+    }
 
     $config = $this->exerciseConfigTransformer->fromExerciseConfig($exerciseConfig);
     $this->sendSuccessResponse($config);

--- a/app/model/entity/ExerciseConfig.php
+++ b/app/model/entity/ExerciseConfig.php
@@ -74,4 +74,16 @@ class ExerciseConfig
     }
   }
 
+  public function equals(?ExerciseConfig $config): bool {
+    if ($config === null) {
+      return false;
+    }
+
+    try {
+      return Yaml::dump($this->getParsedConfig()) === Yaml::dump($config->getParsedConfig());
+    } catch (ExerciseConfigException $exception) {
+      return false;
+    }
+  }
+
 }

--- a/app/model/entity/ExerciseEnvironmentConfig.php
+++ b/app/model/entity/ExerciseEnvironmentConfig.php
@@ -87,4 +87,16 @@ class ExerciseEnvironmentConfig
     }
   }
 
+  public function equals(?ExerciseEnvironmentConfig $other): bool {
+    if ($other === null) {
+      return false;
+    }
+
+    try {
+      return Yaml::dump($this->getParsedVariablesTable()) === Yaml::dump($other->getParsedVariablesTable());
+    } catch (ExerciseConfigException $e) {
+      return false;
+    }
+  }
+
 }

--- a/app/model/entity/ExerciseLimits.php
+++ b/app/model/entity/ExerciseLimits.php
@@ -103,4 +103,16 @@ class ExerciseLimits implements JsonSerializable
     ];
   }
 
+  public function equals(?ExerciseLimits $other): bool {
+    if ($other === null) {
+      return false;
+    }
+
+    try {
+      return Yaml::dump($this->getParsedLimits()) === Yaml::dump($other->getParsedLimits());
+    } catch (ExerciseConfigException $exception) {
+      return false;
+    }
+  }
+
 }


### PR DESCRIPTION
This applies to exercise configs, environment exercise config and exercise limits.