### PR TITLE
Fix erroneous generator usage

### DIFF
--- a/app/V1Module/presenters/SisPresenter.php
+++ b/app/V1Module/presenters/SisPresenter.php
@@ -236,17 +236,20 @@ class SisPresenter extends BasePresenter {
           /** @var Group $group */
           $group = $binding->getGroup();
 
-	  if (!array_key_exists($group->getId(), $groups)) {
-		  $groups[$group->getId()] = $this->groupViewFactory->getGroup($group);
-		  $groups[$group->getId()]["sisCode"] = [];
-	  }
-
-          $serializedGroup = $groups[$group->getId()];
-          $serializedGroup["sisCode"][] = $binding->getCode();
-          $groups[$group->getId()] = $serializedGroup;
+          if (!array_key_exists($group->getId(), $groups)) {
+            $groups[$group->getId()] = $group;
+          }
         }
       }
     }
+
+    // Decorate the groups with associated SIS codes.
+    foreach ($groups as &$group) {
+      $bindings = $this->sisGroupBindings->findByGroup($group);
+      $group = $this->groupViewFactory->getGroup($group);
+      $group["sisCode"] = array_map(function($binding) { return $binding->getCode(); }, $bindings);
+    }
+    unset($group);  // let's clean our hands since we used references
 
     $this->sendSuccessResponse(array_values($groups));
   }

--- a/app/V1Module/presenters/SisPresenter.php
+++ b/app/V1Module/presenters/SisPresenter.php
@@ -235,14 +235,20 @@ class SisPresenter extends BasePresenter {
         if ($binding->getGroup() !== null && !$binding->getGroup()->isArchived()) {
           /** @var Group $group */
           $group = $binding->getGroup();
-          $serializedGroup = $this->groupViewFactory->getGroup($group);
-          $serializedGroup["sisCode"] = $binding->getCode();
-          $groups[] = $serializedGroup;
+
+	  if (!array_key_exists($group->getId(), $groups)) {
+		  $groups[$group->getId()] = $this->groupViewFactory->getGroup($group);
+		  $groups[$group->getId()]["sisCode"] = [];
+	  }
+
+          $serializedGroup = $groups[$group->getId()];
+          $serializedGroup["sisCode"][] = $binding->getCode();
+          $groups[$group->getId()] = $serializedGroup;
         }
       }
     }
 
-    $this->sendSuccessResponse($groups);
+    $this->sendSuccessResponse(array_values($groups));
   }
 
   /**

--- a/app/V1Module/security/Policies/SisBoundGroupPermissionPolicy.php
+++ b/app/V1Module/security/Policies/SisBoundGroupPermissionPolicy.php
@@ -45,7 +45,7 @@ class SisBoundGroupPermissionPolicy implements IPermissionPolicy {
       return false;
     }
 
-    $sisCourses = $this->sisHelper->getCourses($login->getExternalId());
+    $sisCourses = iterator_to_array($this->sisHelper->getCourses($login->getExternalId()));
 
     foreach ($this->bindings->findByGroup($group) as $binding) {
       foreach ($sisCourses as $course) {


### PR DESCRIPTION
If a group is bound to multiple courses, the old code would crash because generators cannot be reused.