### PR TITLE
Group views filtering

### DIFF
--- a/app/V1Module/presenters/SisPresenter.php
+++ b/app/V1Module/presenters/SisPresenter.php
@@ -251,19 +251,11 @@ class SisPresenter extends BasePresenter {
           $group = $binding->getGroup();
 
           if (!array_key_exists($group->getId(), $groups)) {
-            $groups[$group->getId()] = $group;
+            $groups[$group->getId()] = $this->groupViewFactory->getGroup($group);
           }
         }
       }
     }
-
-    // Decorate the groups with associated SIS codes.
-    foreach ($groups as &$group) {
-      $bindings = $this->sisGroupBindings->findByGroup($group);
-      $group = $this->groupViewFactory->getGroup($group);
-      $group["sisCode"] = array_map(function($binding) { return $binding->getCode(); }, $bindings);
-    }
-    unset($group);  // let's clean our hands since we used references
 
     $this->sendSuccessResponse(array_values($groups));
   }

--- a/app/V1Module/security/Policies/SisBoundGroupPermissionPolicy.php
+++ b/app/V1Module/security/Policies/SisBoundGroupPermissionPolicy.php
@@ -47,7 +47,7 @@ class SisBoundGroupPermissionPolicy implements IPermissionPolicy {
 
     $sisCourses = iterator_to_array($this->sisHelper->getCourses($login->getExternalId()));
 
-    foreach ($this->bindings->findByGroup($group) as $binding) {
+    foreach ($this->bindings->findGroupBindings($group) as $binding) {
       foreach ($sisCourses as $course) {
         if ($course->isOwnerStudent() && $binding->getCode() === $course->getCode()) {
           return true;

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -199,6 +199,7 @@ extensions:
   doctrine: Kdyby\Doctrine\DI\OrmExtension
   fixtures: Zenify\DoctrineFixtures\DI\FixturesExtension
   acl: App\Security\SecurityExtension(%tempDir%)
+  groupBindings: App\Helpers\GroupBindings\GroupBindingsExtension
 
 decorator:
   Symfony\Component\Console\Command\Command:

--- a/app/helpers/GroupBindings/GroupBindingAccessor.php
+++ b/app/helpers/GroupBindings/GroupBindingAccessor.php
@@ -17,7 +17,11 @@ class GroupBindingAccessor {
   public function getBindingsForGroup(Group $group) {
     $result = [];
     foreach ($this->providers as $provider) {
-      $result[$provider->getGroupBindingIdentifier()] = $provider->findGroupBindings($group);
+      $result[$provider->getGroupBindingIdentifier()] = [];
+
+      foreach ($provider->findGroupBindings($group) as $binding) {
+        $result[$provider->getGroupBindingIdentifier()][] = (string) $binding;
+      }
     }
     return $result;
   }

--- a/app/helpers/GroupBindings/GroupBindingAccessor.php
+++ b/app/helpers/GroupBindings/GroupBindingAccessor.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Helpers\GroupBindings;
+
+use App\Model\Entity\Group;
+
+/**
+ * Provides access to instances of IGroupBindingProvider
+ */
+class GroupBindingAccessor {
+  /** @var IGroupBindingProvider[] */
+  private $providers = [];
+
+  public function addProvider(IGroupBindingProvider $provider) {
+    $this->providers[] = $provider;
+  }
+
+  public function getBindingsForGroup(Group $group) {
+    $result = [];
+    foreach ($this->providers as $provider) {
+      $result[$provider->getGroupBindingIdentifier()] = $provider->findGroupBindings($group);
+    }
+    return $result;
+  }
+}

--- a/app/helpers/GroupBindings/GroupBindingsExtension.php
+++ b/app/helpers/GroupBindings/GroupBindingsExtension.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Helpers\GroupBindings;
+use Nette;
+
+/**
+ * Looks up all IGroupBindingProvider implementations and registers them in a GroupBindingAccessor
+ */
+class GroupBindingsExtension extends Nette\DI\CompilerExtension {
+  public function loadConfiguration() {
+    $accessor = $this->getContainerBuilder()->addDefinition($this->prefix("groupBindingsAccessor"));
+    $accessor->factory = new Nette\DI\Statement(GroupBindingAccessor::class);
+  }
+
+  public function beforeCompile() {
+    $builder = $this->getContainerBuilder();
+    $accessor = $builder->getDefinition($this->prefix("groupBindingsAccessor"));
+    foreach (array_keys($builder->findByType(IGroupBindingProvider::class)) as $name) {
+      $accessor->addSetup("addProvider", ["@" . $name]);
+    }
+  }
+}

--- a/app/helpers/GroupBindings/IGroupBindingProvider.php
+++ b/app/helpers/GroupBindings/IGroupBindingProvider.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Helpers\GroupBindings;
+
+use App\Model\Entity\Group;
+
+interface IGroupBindingProvider {
+  /**
+   * @return string a unique identifier of the type of the binding
+   */
+  public function getGroupBindingIdentifier(): string;
+
+  /**
+   * @param Group $group
+   * @return array all entities bound to the group (they must have __toString() implemented)
+   */
+  public function findGroupBindings(Group $group): array;
+}

--- a/app/model/entity/SisGroupBinding.php
+++ b/app/model/entity/SisGroupBinding.php
@@ -40,4 +40,8 @@ class SisGroupBinding {
   public function getCode() {
     return $this->code;
   }
+
+  public function __toString() {
+    return $this->code;
+  }
 }

--- a/app/model/repository/SisGroupBindings.php
+++ b/app/model/repository/SisGroupBindings.php
@@ -1,11 +1,12 @@
 <?php
 namespace App\Model\Repository;
 
+use App\Helpers\GroupBindings\IGroupBindingProvider;
 use App\Model\Entity\Group;
 use App\Model\Entity\SisGroupBinding;
 use Kdyby\Doctrine\EntityManager;
 
-class SisGroupBindings extends BaseRepository {
+class SisGroupBindings extends BaseRepository implements IGroupBindingProvider {
   public function __construct(EntityManager $em) {
     parent::__construct($em, SisGroupBinding::class);
   }
@@ -34,10 +35,17 @@ class SisGroupBindings extends BaseRepository {
   }
 
   /**
-   * @param Group $group
-   * @return SisGroupBinding[]
+   * @return string a unique identifier of the type of the binding
    */
-  public function findByGroup(Group $group) {
+  public function getGroupBindingIdentifier(): string {
+    return "sis";
+  }
+
+  /**
+   * @param Group $group
+   * @return array all entities bound to the group (they must have __toString() implemented)
+   */
+  public function findGroupBindings(Group $group): array {
     return $this->findBy([
       "group" => $group
     ]);

--- a/app/model/view/GroupViewFactory.php
+++ b/app/model/view/GroupViewFactory.php
@@ -143,19 +143,9 @@ class GroupViewFactory {
       ];
     }
 
-    $childGroups = $group->getChildGroups();
-    $publicChildGroups = $group->getPublicChildGroups();
-
-    if ($ignoreArchived) {
-      $childGroups = $childGroups->filter(function (Group $group) {
-        return !$group->isArchived();
-      });
-
-      $publicChildGroups = $publicChildGroups->filter(function (Group $group) {
-        return !$group->isArchived();
-      });
-    }
-
+    $childGroups = $group->getChildGroups()->filter(function (Group $group) use ($ignoreArchived) {
+      return !($ignoreArchived && $group->isArchived()) && $this->groupAcl->canViewPublicDetail($group);
+    });
 
     return [
       "id" => $group->getId(),
@@ -170,10 +160,7 @@ class GroupViewFactory {
       })->getValues(),
       "parentGroupId" => $group->getParentGroup() ? $group->getParentGroup()->getId() : null,
       "parentGroupsIds" => $group->getParentGroupsIds(),
-      "childGroups" => [
-        "all" => $childGroups->map(function (Group $group) { return $group->getId(); })->getValues(),
-        "public" => $publicChildGroups->map(function (Group $group) { return $group->getId(); })->getValues()
-      ],
+      "childGroups" => $childGroups->map(function (Group $group) { return $group->getId(); })->getValues(),
       "canView" => $canView,
       "privateData" => $privateData
     ];

--- a/app/model/view/GroupViewFactory.php
+++ b/app/model/view/GroupViewFactory.php
@@ -3,6 +3,7 @@
 namespace App\Model\View;
 
 use App\Helpers\EvaluationStatus\EvaluationStatus;
+use App\Helpers\GroupBindings\GroupBindingAccessor;
 use App\Helpers\Localizations;
 use App\Helpers\Pair;
 use App\Model\Entity\Assignment;
@@ -37,10 +38,14 @@ class GroupViewFactory {
    */
   private $assignmentAcl;
 
-  public function __construct(AssignmentSolutions $assignmentSolutions, IGroupPermissions $groupAcl, IAssignmentPermissions $assignmentAcl) {
+  /** @var GroupBindingAccessor */
+  private $bindings;
+
+  public function __construct(AssignmentSolutions $assignmentSolutions, IGroupPermissions $groupAcl, IAssignmentPermissions $assignmentAcl, GroupBindingAccessor $bindings) {
     $this->assignmentSolutions = $assignmentSolutions;
     $this->groupAcl = $groupAcl;
     $this->assignmentAcl = $assignmentAcl;
+    $this->bindings = $bindings;
   }
 
 
@@ -135,7 +140,8 @@ class GroupViewFactory {
           })->getValues(),
         "publicStats" => $group->getPublicStats(),
         "isPublic" => $group->isPublic(),
-        "threshold" => $group->getThreshold()
+        "threshold" => $group->getThreshold(),
+        "bindings" => $this->bindings->getBindingsForGroup($group)
       ];
     }
 

--- a/app/model/view/GroupViewFactory.php
+++ b/app/model/view/GroupViewFactory.php
@@ -41,7 +41,8 @@ class GroupViewFactory {
   /** @var GroupBindingAccessor */
   private $bindings;
 
-  public function __construct(AssignmentSolutions $assignmentSolutions, IGroupPermissions $groupAcl, IAssignmentPermissions $assignmentAcl, GroupBindingAccessor $bindings) {
+  public function __construct(AssignmentSolutions $assignmentSolutions, IGroupPermissions $groupAcl,
+                              IAssignmentPermissions $assignmentAcl, GroupBindingAccessor $bindings) {
     $this->assignmentSolutions = $assignmentSolutions;
     $this->groupAcl = $groupAcl;
     $this->assignmentAcl = $assignmentAcl;

--- a/app/model/view/GroupViewFactory.php
+++ b/app/model/view/GroupViewFactory.php
@@ -127,7 +127,6 @@ class GroupViewFactory {
     $privateData = null;
     if ($canView) {
       $privateData = [
-        "description" => $primaryLocalization ? $primaryLocalization->getDescription() : "", # BC
         "admins" => $group->getAdminsIds(),
         "supervisors" => $group->getSupervisors()->map(function(User $s) { return $s->getId(); })->getValues(),
         "students" => $group->getStudents()->map(function(User $s) { return $s->getId(); })->getValues(),
@@ -139,7 +138,6 @@ class GroupViewFactory {
             return $assignment->getId();
           })->getValues(),
         "publicStats" => $group->getPublicStats(),
-        "isPublic" => $group->isPublic(),
         "threshold" => $group->getThreshold(),
         "bindings" => $this->bindings->getBindingsForGroup($group)
       ];
@@ -164,9 +162,9 @@ class GroupViewFactory {
       "externalId" => $group->getExternalId(),
       "organizational" => $group->isOrganizational(),
       "archived" => $group->isArchived(),
+      "public" => $group->isPublic(),
       "directlyArchived" => $group->isDirectlyArchived(),
       "localizedTexts" => $group->getLocalizedTexts()->getValues(),
-      "name" => $primaryLocalization ? $primaryLocalization->getName() : "", # BC
       "primaryAdminsIds" => $group->getPrimaryAdmins()->map(function (User $user) {
         return $user->getId();
       })->getValues(),

--- a/tests/Presenters/GroupsPresenter.phpt
+++ b/tests/Presenters/GroupsPresenter.phpt
@@ -219,7 +219,7 @@ class TestGroupsPresenter extends Tester\TestCase
     Assert::equal('external identification of exercise', $payload["externalId"]);
     Assert::equal($instance->getRootGroup()->getId(), $payload["parentGroupId"]);
     Assert::equal(true, $payload["privateData"]["publicStats"]);
-    Assert::equal(true, $payload["privateData"]["isPublic"]);
+    Assert::equal(true, $payload["public"]);
   }
 
   public function testValidateAddGroupData()
@@ -326,7 +326,7 @@ class TestGroupsPresenter extends Tester\TestCase
     Assert::equal('some neaty description', $localizedGroup->getDescription());
     Assert::equal('external identification of exercise', $payload["externalId"]);
     Assert::equal(true, $payload["privateData"]["publicStats"]);
-    Assert::equal(true, $payload["privateData"]["isPublic"]);
+    Assert::equal(true, $payload["public"]);
     Assert::equal(0.8, $payload["privateData"]["threshold"]);
   }
 

--- a/tests/Presenters/SisPresenter.phpt
+++ b/tests/Presenters/SisPresenter.phpt
@@ -3,7 +3,6 @@ $container = require_once __DIR__ . "/../bootstrap.php";
 
 use App\Helpers\SisHelper;
 use App\Model\Entity\ExternalLogin;
-use App\Model\Entity\Group;
 use App\Model\Entity\SisGroupBinding;
 use App\Model\Entity\SisValidTerm;
 use App\Model\Entity\User;
@@ -294,8 +293,8 @@ class TestSisPresenter extends TestCase {
     $group = $groups[0];
     $binding_1 = new SisGroupBinding($group, "code1");
     $this->em->persist($binding_1);
-    $binding_1 = new SisGroupBinding($group, "code2");
-    $this->em->persist($binding_1);
+    $binding_2 = new SisGroupBinding($group, "code2");
+    $this->em->persist($binding_2);
     $this->em->flush();
 
     /** @var GroupViewFactory $groupViewFactory */
@@ -303,6 +302,10 @@ class TestSisPresenter extends TestCase {
 
     $view = $groupViewFactory->getGroup($group);
     Assert::count(2, $view["privateData"]["bindings"]["sis"]);
+
+    sort($view["privateData"]["bindings"]["sis"]);
+    Assert::equal("code1", $view["privateData"]["bindings"]["sis"][0]);
+    Assert::equal("code2", $view["privateData"]["bindings"]["sis"][1]);
   }
 }
 


### PR DESCRIPTION
Breaking changes:
- sisCode disappeared from Group entity (replaced with private.bindings.sis)
- assignments array was flattened in Group entity
- childGroups array was flattened in Group entity