### PR TITLE
Fix: correctly return 401 on invalid token

### DIFF
--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -11,8 +11,8 @@ class Bootstrap
         $configurator = new Configurator;
 
         //$configurator->setDebugMode('secret@23.75.345.200'); // enable for your remote IP
-        $configurator->enableTracy(__DIR__ . '/../log');
         // $configurator->setDebugMode(false);
+        $configurator->enableTracy(__DIR__ . '/../log');
 
         $configurator->setTimeZone('Europe/Prague');
         $configurator->setTempDirectory(__DIR__ . '/../temp');

--- a/app/V1Module/presenters/base/ApiErrorPresenter.php
+++ b/app/V1Module/presenters/base/ApiErrorPresenter.php
@@ -111,8 +111,11 @@ class ApiErrorPresenter extends \App\Presenters\BasePresenter
         string $frontendErrorCode = FrontendErrorMappings::E500_000__INTERNAL_SERVER_ERROR,
         $frontendErrorParams = null
     ) {
-        // log the action done by the current user
-        if ($this->getUser()->isLoggedIn()) {
+        // calling user->isLoggedIn results in throwing exception in case of
+        // invalid token (after update to nette/security:v3.1), therefore we
+        // need to call our UserStorage directly
+        if ($this->getUser()->getStorage()->isAuthenticated()) {
+            // log the action done by the current user
             // determine the action name from the application request
             $req = $this->getRequest();
             $params = $req->getParameters();


### PR DESCRIPTION
Fix: nette/security update changed behavior of User security structure, mimic the previous behavior by calling user-storage directly