### PR TITLE
The async job dispatcher should dump the doctrine entity caches since…

### DIFF
--- a/app/async/Dispatcher.php
+++ b/app/async/Dispatcher.php
@@ -112,9 +112,15 @@ class Dispatcher
             throw new InvalidArgumentException("Unknown async job type '$command'.");
         }
 
+        // clear entity cache to make sure the job will load fresh data from DB
+        $jobId = $job->getId();
+        $this->entityManager->clear();
+        $jobReloaded = $this->asyncJobs->findOrThrow($jobId);
+
+
         // pending handler is set so it can be interrupted by async handler
         $this->pendingHandler = $this->knownHandlers[$command];
-        $this->pendingHandler->execute($job);
+        $this->pendingHandler->execute($jobReloaded);
         $this->pendingHandler = null;
     }
 

--- a/app/helpers/BrokerProxy.php
+++ b/app/helpers/BrokerProxy.php
@@ -19,13 +19,13 @@ use Nette\Utils\Arrays;
 class BrokerProxy
 {
 
-    const EXPECTED_RESULT = "accept";
-    const REJECTED_RESULT = "reject";
-    const EXPECTED_ACK = "ack";
+    private const EXPECTED_RESULT = "accept";
+    private const REJECTED_RESULT = "reject";
+    private const EXPECTED_ACK = "ack";
 
-    const COMMAND_STATS = "get-runtime-stats";
-    const COMMAND_FREEZE = "freeze";
-    const COMMAND_UNFREEZE = "unfreeze";
+    private const COMMAND_STATS = "get-runtime-stats";
+    private const COMMAND_FREEZE = "freeze";
+    private const COMMAND_UNFREEZE = "unfreeze";
 
     /** @var string IP address or hostname (with port) of ReCodEx broker */
     private $brokerAddress;
@@ -108,7 +108,8 @@ class BrokerProxy
         if ($ack[0] !== self::EXPECTED_ACK) {
             $queue->disconnect($this->brokerAddress);
             throw new SubmissionFailedException(
-                "Broker did not send correct acknowledgement message, expected '" . self::EXPECTED_ACK . "', but received '$ack[0]' instead."
+                "Broker did not send correct acknowledgement message, expected '"
+                    . self::EXPECTED_ACK . "', but received '$ack[0]' instead."
             );
         }
 

--- a/tests/Presenters/AsyncJobsPresenter.phpt
+++ b/tests/Presenters/AsyncJobsPresenter.phpt
@@ -81,6 +81,7 @@ class TestAsyncJobsPresenter extends Tester\TestCase
         PresenterTestHelper::loginDefaultAdmin($this->container);
 
         $asyncJob = PresenterTestHelper::performPresenterRequest($this->presenter, 'V1:AsyncJobs', 'POST', ['action' => 'ping']);
+        $asyncJobId = $asyncJob->getId();
 
         Assert::type(AsyncJob::class, $asyncJob);
         Assert::equal('ping', $asyncJob->getCommand());
@@ -89,6 +90,7 @@ class TestAsyncJobsPresenter extends Tester\TestCase
         $worker = $this->createWorker();
         $worker->run('w1');
 
+        $asyncJob = $this->asyncJobs->findOrThrow($asyncJobId); // complete reload since worker erases em caches
         $asyncJob2 = PresenterTestHelper::performPresenterRequest(
             $this->presenter,
             'V1:AsyncJobs',
@@ -98,8 +100,6 @@ class TestAsyncJobsPresenter extends Tester\TestCase
 
         Assert::type(AsyncJob::class, $asyncJob2);
         Assert::equal($asyncJob->getId(), $asyncJob2->getId());
-
-        $this->asyncJobs->refresh($asyncJob);
         Assert::truthy($asyncJob->getFinishedAt());
         Assert::null($asyncJob->getError());
     }


### PR DESCRIPTION
… the worker may be running for a while and caching old data.