### PR TITLE
Flipped join/implode params (https://www.php.net/manual/en/function.i…

### DIFF
--- a/app/commands/runtimes/RuntimeImport.php
+++ b/app/commands/runtimes/RuntimeImport.php
@@ -153,7 +153,7 @@ class RuntimeImport extends BaseCommand
     {
         foreach ($schema as $key => $desc) {
             // check existence
-            $path = $prefix ? ("'" . join($prefix, "' / '") . "'") : '<root>';
+            $path = $prefix ? ("'" . join("' / '", $prefix) . "'") : '<root>';
             if (!array_key_exists($key, $obj)) {
                 throw new RuntimeException("Property '$key' is missing in $path structure.");
             }


### PR DESCRIPTION
In PHP74 passing the separator after the array (i.e. using the legacy signature) has been deprecated. 
https://www.php.net/manual/en/function.implode.php#changelog